### PR TITLE
Update Shared package versions and config access method

### DIFF
--- a/MobileConfiguration/MobileConfiguration.csproj
+++ b/MobileConfiguration/MobileConfiguration.csproj
@@ -65,9 +65,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.1" />
-    <PackageReference Include="Shared" Version="2026.2.1" />
-    <PackageReference Include="Shared.Logger" Version="2026.2.1" />
-    <PackageReference Include="Shared.Results.Web" Version="2026.2.1" />
+    <PackageReference Include="Shared" Version="2026.2.2" />
+    <PackageReference Include="Shared.Logger" Version="2026.2.2" />
+    <PackageReference Include="Shared.Results.Web" Version="2026.2.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">

--- a/MobileConfiguration/Program.cs
+++ b/MobileConfiguration/Program.cs
@@ -82,9 +82,9 @@ else {
     builder.Services.AddDbContext<ConfigurationContext>(options =>
         options.UseSqlServer(configuration.GetConnectionString("ConfigurationDatabase")));
 }
-bool logRequests = ConfigurationReaderExtensions.GetValueOrDefault<Boolean>("MiddlewareLogging", "LogRequests", true);
-bool logResponses = ConfigurationReaderExtensions.GetValueOrDefault<Boolean>("MiddlewareLogging", "LogResponses", true);
-LogLevel middlewareLogLevel = ConfigurationReaderExtensions.GetValueOrDefault("MiddlewareLogging", "MiddlewareLogLevel", LogLevel.Warning);
+bool logRequests = ConfigurationReader.GetValueOrDefault<Boolean>("MiddlewareLogging", "LogRequests", true);
+bool logResponses = ConfigurationReader.GetValueOrDefault<Boolean>("MiddlewareLogging", "LogResponses", true);
+LogLevel middlewareLogLevel = ConfigurationReader.GetValueOrDefault("MiddlewareLogging", "MiddlewareLogLevel", LogLevel.Warning);
 
 RequestResponseMiddlewareLoggingConfig config = new(middlewareLogLevel, logRequests, logResponses);
 
@@ -130,25 +130,6 @@ async Task InitializeDatabase(IApplicationBuilder app)
         if (dbContext!= null && dbContext.Database.IsRelational())
         {
             await dbContext.MigrateAsync(CancellationToken.None);
-        }
-    }
-}
-
-public static class ConfigurationReaderExtensions {
-    public static T GetValueOrDefault<T>(String sectionName,
-                                         String keyName,
-                                         T defaultValue) {
-        try {
-            var value = ConfigurationReader.GetValue(sectionName, keyName);
-
-            if (String.IsNullOrEmpty(value)) {
-                return defaultValue;
-            }
-
-            return (T)Convert.ChangeType(value, typeof(T));
-        }
-        catch (KeyNotFoundException kex) {
-            return defaultValue;
         }
     }
 }


### PR DESCRIPTION
Updated Shared, Shared.Logger, and Shared.Results.Web packages to version 2026.2.2. Replaced usage of ConfigurationReaderExtensions.GetValueOrDefault with ConfigurationReader.GetValueOrDefault in Program.cs, and removed the now-obsolete ConfigurationReaderExtensions class. These changes align with updates in the Shared package.

closes #89 