### PR TITLE
Configure Sentry options via app configuration

### DIFF
--- a/MobileConfiguration/Program.cs
+++ b/MobileConfiguration/Program.cs
@@ -43,7 +43,8 @@ if (sentrySection != "N/A")
             o.Dsn = sentrySection;
             o.SendDefaultPii = true;
             o.MaxRequestBodySize = RequestSize.Always;
-            o.CaptureBlockingCalls = true;
+            o.CaptureBlockingCalls = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "CaptureBlockingCalls", false);
+            o.IncludeActivityData = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "IncludeActivityData", false);
             o.Release = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
         });
     }


### PR DESCRIPTION
CaptureBlockingCalls and IncludeActivityData are now set based on values from the application's configuration, allowing these Sentry options to be toggled without code changes. This improves flexibility and maintainability.

closes #96 