### PR TITLE
Replace Newtonsoft.Json with Shared.Serialisation

### DIFF
--- a/MobileConfiguration/Factories/Factory.cs
+++ b/MobileConfiguration/Factories/Factory.cs
@@ -1,6 +1,6 @@
 ﻿using MobileConfiguration.DataTransferObjects;
 using MobileConfiguration.Models;
-using Newtonsoft.Json;
+using Shared.Serialisation;
 using HostAddress = MobileConfiguration.DataTransferObjects.HostAddress;
 using LoggingLevel = MobileConfiguration.DataTransferObjects.LoggingLevel;
 using ServiceType = MobileConfiguration.DataTransferObjects.ServiceType;
@@ -61,7 +61,7 @@ namespace MobileConfiguration.Factories
                 DeviceIdentifier = configurationModel.DeviceIdentifier,
                 EnableAutoUpdates = configurationModel.EnableAutoUpdates,
                 LogLevelId = (Int32)configurationModel.LogLevel,
-                HostAddresses = JsonConvert.SerializeObject(configurationModel.HostAddresses)
+                HostAddresses = StringSerialiser.Serialise(configurationModel.HostAddresses)
             };
 
             return configurationEntity;

--- a/MobileConfiguration/Handlers/TransactionMobileLoggingHandler.cs
+++ b/MobileConfiguration/Handlers/TransactionMobileLoggingHandler.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using MobileConfiguration.DataTransferObjects;
-using Newtonsoft.Json;
 using Shared.Logger;
+using Shared.Serialisation;
 
 namespace MobileConfiguration.Handlers
 {
@@ -9,7 +9,7 @@ namespace MobileConfiguration.Handlers
     {
         public static Task<IResult> PostLogging(List<LogMessage> logMessages, CancellationToken cancellationToken)
         {
-            Logger.LogInformation(JsonConvert.SerializeObject(logMessages));
+            Logger.LogInformation(StringSerialiser.Serialise(logMessages));
             return Task.FromResult(Results.Ok() as IResult);
         }
     }

--- a/MobileConfiguration/MobileConfiguration.csproj
+++ b/MobileConfiguration/MobileConfiguration.csproj
@@ -7,54 +7,7 @@
     <UserSecretsId>8795d0e9-2509-41b8-b1e1-f28f8468338b</UserSecretsId>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\cs\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\de\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\es\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\fr\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\it\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\ja\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\ko\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\Microsoft.Build.Locator.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.exe" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.exe.config" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\Microsoft.IO.Redist.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\Newtonsoft.Json.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\pl\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\pt-BR\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\ru\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\System.Buffers.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\System.Collections.Immutable.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\System.CommandLine.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\System.Memory.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\System.Numerics.Vectors.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\System.Runtime.CompilerServices.Unsafe.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\System.Threading.Tasks.Extensions.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\tr\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\zh-Hans\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-net472\zh-Hant\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-netcore\cs\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-netcore\de\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-netcore\es\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-netcore\fr\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-netcore\it\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-netcore\ja\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-netcore\ko\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-netcore\Microsoft.Build.Locator.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-netcore\Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.deps.json" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-netcore\Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-netcore\Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.dll.config" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-netcore\Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.runtimeconfig.json" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-netcore\Newtonsoft.Json.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-netcore\pl\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-netcore\pt-BR\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-netcore\ru\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-netcore\System.Collections.Immutable.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-netcore\System.CommandLine.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-netcore\tr\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-netcore\zh-Hans\System.CommandLine.resources.dll" />
-    <Content Remove="C:\Users\stuar\.nuget\packages\microsoft.codeanalysis.workspaces.msbuild\4.14.0\contentFiles\any\any\BuildHost-netcore\zh-Hant\System.CommandLine.resources.dll" />
-  </ItemGroup>
+  
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
@@ -65,9 +18,9 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.1" />
-    <PackageReference Include="Shared" Version="2026.2.2" />
-    <PackageReference Include="Shared.Logger" Version="2026.2.2" />
-    <PackageReference Include="Shared.Results.Web" Version="2026.2.2" />
+    <PackageReference Include="Shared" Version="2026.5.6" />
+    <PackageReference Include="Shared.Logger" Version="2026.5.6" />
+    <PackageReference Include="Shared.Results.Web" Version="2026.5.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">

--- a/MobileConfiguration/Program.cs
+++ b/MobileConfiguration/Program.cs
@@ -1,8 +1,4 @@
-using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Diagnostics;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
 using MobileConfiguration.Database;
 using MobileConfiguration.Repository;
 using NLog;
@@ -14,10 +10,11 @@ using Shared.General;
 using Shared.Logger;
 using Shared.Logger.TennantContext;
 using Shared.Middleware;
+using Shared.Serialisation;
+using System.ComponentModel;
 using System.Reflection;
-using System.Runtime.CompilerServices;
+using System.Text.Json;
 using ILogger = Microsoft.Extensions.Logging.ILogger;
-using Logger = NLog.Logger;
 using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
@@ -111,8 +108,17 @@ RequestResponseMiddlewareLoggingConfig config = new(middlewareLogLevel, logReque
 
 builder.Services.AddSingleton(config);
 
-
+builder.Services.AddSingleton<IStringSerialiser, SystemTextJsonSerializer>();
+builder.Services.AddSingleton<Func<Object, String>>(_ => obj => StringSerialiser.Serialise(obj));
+builder.Services.AddSingleton<Func<String, Type, Object>>(_ => (str, type) => StringSerialiser.DeserializeObject<Object>(str, type));
+builder.Services.AddSingleton(SystemTextJsonSerializer.GetDefaultJsonSerializerOptions());
+builder.Services.ConfigureHttpJsonOptions(options => {
+    JsonSerializerConfiguration.ConfigureMinimalApi(options.SerializerOptions);
+});
 var app = builder.Build();
+
+var serialiser = app.Services.GetRequiredService<IStringSerialiser>();
+StringSerialiser.Initialise(serialiser);
 
 app.UseMiddleware<TenantMiddleware>();
 
@@ -120,13 +126,10 @@ app.UseSwagger();
 app.UseSwaggerUI();
 
 
-
-
 // Configure the HTTP request pipeline.
 app.UseAuthorization();
 
-app.AddRequestLogging();
-app.AddResponseLogging();
+app.AddRequestResponseLogging();
 app.AddExceptionHandler();
 
 
@@ -152,5 +155,19 @@ async Task InitializeDatabase(IApplicationBuilder app)
         {
             await dbContext.MigrateAsync(CancellationToken.None);
         }
+    }
+}
+
+
+public static class JsonSerializerConfiguration
+{
+    public static void ConfigureMinimalApi(JsonSerializerOptions serializerOptions)
+    {
+        var defaultOptions = SystemTextJsonSerializer.GetDefaultJsonSerializerOptions();
+        serializerOptions.PropertyNamingPolicy = defaultOptions.PropertyNamingPolicy;
+        serializerOptions.DictionaryKeyPolicy = defaultOptions.DictionaryKeyPolicy;
+        serializerOptions.ReferenceHandler = defaultOptions.ReferenceHandler;
+        serializerOptions.WriteIndented = defaultOptions.WriteIndented;
+        serializerOptions.Converters.Add(new DateTimeSpaceConverter());
     }
 }

--- a/MobileConfiguration/Repository/IConfigurationRepository.cs
+++ b/MobileConfiguration/Repository/IConfigurationRepository.cs
@@ -6,9 +6,9 @@ namespace MobileConfiguration.Repository
     using Database.Entities;
     using Microsoft.EntityFrameworkCore;
     using Models;
-    using Newtonsoft.Json;
     using Shared.EntityFramework;
     using Shared.Exceptions;
+    using Shared.Serialisation;
 
     public interface IConfigurationRepository
     {
@@ -45,7 +45,7 @@ namespace MobileConfiguration.Repository
                                                                                  EnableAutoUpdates = configuration.EnableAutoUpdates,
                                                                                  Id = configuration.Id,
                                                                                  HostAddresses =
-                                                                                     JsonConvert.DeserializeObject<List<HostAddress>>(configuration.HostAddresses)
+                                                                                     StringSerialiser.Deserialise<List<HostAddress>>(configuration.HostAddresses)
                                                                              };
 
             configurationModel.LogLevel = configuration.LogLevelId switch
@@ -93,7 +93,7 @@ namespace MobileConfiguration.Repository
                                                       LogLevelId = (Int32)mobileConfiguration.LogLevel,
                                                       ClientId = mobileConfiguration.ClientId,
                                                       EnableAutoUpdates = mobileConfiguration.EnableAutoUpdates,
-                                                      HostAddresses = JsonConvert.SerializeObject(mobileConfiguration.HostAddresses),
+                                                      HostAddresses = StringSerialiser.Serialise(mobileConfiguration.HostAddresses),
                                                       ConfigType = (Int32)mobileConfiguration.ConfigurationType,
                                                       Id = mobileConfiguration.Id,
                                                   };
@@ -105,7 +105,7 @@ namespace MobileConfiguration.Repository
                 configuration.LogLevelId = (Int32)mobileConfiguration.LogLevel;
                 configuration.ClientId = mobileConfiguration.ClientId;
                 configuration.EnableAutoUpdates = mobileConfiguration.EnableAutoUpdates;
-                configuration.HostAddresses = JsonConvert.SerializeObject(mobileConfiguration.HostAddresses);
+                configuration.HostAddresses = StringSerialiser.Serialise(mobileConfiguration.HostAddresses);
             }
 
             await resolvedContext.Context.SaveChangesAsync(cancellationToken);


### PR DESCRIPTION
Refactored all serialization/deserialization to use StringSerialiser from Shared.Serialisation instead of Newtonsoft.Json. Updated DI in Program.cs to register IStringSerialiser and related delegates. Upgraded Shared package dependencies to 2026.5.6. Added JsonSerializerConfiguration for minimal API options. Updated middleware logging to use AddRequestResponseLogging. Cleaned up using directives accordingly.

closes #98 