### PR TITLE
Change HostAddress.ServiceType to Int32 in model

### DIFF
--- a/MobileConfiguration/Factories/Factory.cs
+++ b/MobileConfiguration/Factories/Factory.cs
@@ -25,12 +25,13 @@ namespace MobileConfiguration.Factories
             {
                 Models.HostAddress hostAddressModel = new()
                 {
-                    Uri = configurationHostAddress.Uri, ServiceType = configurationHostAddress.ServiceType switch
+                    Uri = configurationHostAddress.Uri,
+                    ServiceType = configurationHostAddress.ServiceType switch
                     {
-                        ServiceType.EstateManagement => Models.ServiceType.EstateManagement,
-                        ServiceType.TransactionProcessorAcl => Models.ServiceType.TransactionProcessorAcl,
-                        ServiceType.VoucherManagementAcl => Models.ServiceType.VoucherManagementAcl,
-                        _ => Models.ServiceType.Security
+                        ServiceType.EstateManagement => (Int32)Models.ServiceType.EstateManagement,
+                        ServiceType.TransactionProcessorAcl => (Int32)Models.ServiceType.TransactionProcessorAcl,
+                        ServiceType.VoucherManagementAcl => (Int32)Models.ServiceType.VoucherManagementAcl,
+                        _ => (Int32)Models.ServiceType.Security
                     }
                 };
 
@@ -84,7 +85,7 @@ namespace MobileConfiguration.Factories
                 {
                     Uri = configurationHostAddress.Uri,
                 };
-                hostAddress.ServiceType = configurationHostAddress.ServiceType switch
+                hostAddress.ServiceType = (Models.ServiceType)configurationHostAddress.ServiceType switch
                 {
                     Models.ServiceType.TransactionProcessorAcl => ServiceType.TransactionProcessorAcl,
                     _ => ServiceType.Security

--- a/MobileConfiguration/Models/Models.cs
+++ b/MobileConfiguration/Models/Models.cs
@@ -20,7 +20,7 @@
 
     public class HostAddress
     {
-        public ServiceType ServiceType { get; set; }
+        public Int32 ServiceType { get; set; }
 
         public String Uri { get; set; }
     }


### PR DESCRIPTION
Updated HostAddress model to store ServiceType as Int32 instead of enum. Adjusted Factory.cs to cast between enum and Int32 when mapping between domain and model objects, preserving enum logic in factories.