### PR TITLE
Enable Central Package Management for NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,22 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <PackageVersion Include="NLog.Web.AspNetCore" Version="6.1.3" />
+    <PackageVersion Include="Shared" Version="2026.5.7" />
+    <PackageVersion Include="Shared.Logger" Version="2026.5.7" />
+    <PackageVersion Include="Shared.Results.Web" Version="2026.5.7" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.9" />
+    <PackageVersion Include="Sentry.AspNetCore" Version="6.6.0" />
+  </ItemGroup>
+</Project>

--- a/MobileConfiguration.sln
+++ b/MobileConfiguration.sln
@@ -5,6 +5,11 @@ VisualStudioVersion = 17.5.33209.295
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MobileConfiguration", "MobileConfiguration\MobileConfiguration.csproj", "{57BB2307-565F-4A70-B3AA-685FDEFCCCFA}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A9C2E3D1-6F3B-4C5A-9C8E-111111111111}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Packages.props = Directory.Packages.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/MobileConfiguration/Dockerfile
+++ b/MobileConfiguration/Dockerfile
@@ -5,6 +5,8 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 COPY ["MobileConfiguration/NuGet.Config", "MobileConfiguration/"]
 COPY ["MobileConfiguration/MobileConfiguration.csproj", "MobileConfiguration/"]
+COPY ["Directory.Packages.props", "."]
+COPY . .
 
 RUN dotnet restore "MobileConfiguration/MobileConfiguration.csproj"
 COPY . .

--- a/MobileConfiguration/Dockerfilewindows
+++ b/MobileConfiguration/Dockerfilewindows
@@ -6,6 +6,8 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0-windowsservercore-ltsc2022 AS build
 WORKDIR /src
 COPY ["MobileConfiguration/NuGet.Config", "MobileConfiguration/"]
 COPY ["MobileConfiguration/MobileConfiguration.csproj", "MobileConfiguration/"]
+COPY ["Directory.Packages.props", "."]
+COPY . .
 
 RUN dotnet restore "MobileConfiguration/MobileConfiguration.csproj"
 COPY . .

--- a/MobileConfiguration/MobileConfiguration.csproj
+++ b/MobileConfiguration/MobileConfiguration.csproj
@@ -5,32 +5,33 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>8795d0e9-2509-41b8-b1e1-f28f8468338b</UserSecretsId>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.3">
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="NLog.Web.AspNetCore" Version="6.1.1" />
-    <PackageReference Include="Shared" Version="2026.5.6" />
-    <PackageReference Include="Shared.Logger" Version="2026.5.6" />
-    <PackageReference Include="Shared.Results.Web" Version="2026.5.6" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
+    <PackageReference Include="NLog.Web.AspNetCore" />
+    <PackageReference Include="Shared" />
+    <PackageReference Include="Shared.Logger" />
+    <PackageReference Include="Shared.Results.Web" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.3" />
-    <PackageReference Include="Sentry.AspNetCore" Version="6.2.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
+    <PackageReference Include="Sentry.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Set ManagePackageVersionsCentrally to true in MobileConfiguration.csproj and remove explicit package versions. Add Directory.Packages.props to centrally manage all NuGet package versions for improved maintainability.

closes #103 